### PR TITLE
clang-format: Handle doctest TEST_SUITE macro as a namespace

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -94,6 +94,7 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+NamespaceMacros: ['TEST_SUITE']
 ObjCBinPackProtocolList: Never
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: true


### PR DESCRIPTION
The setting NamespaceMacros lists all macros that act as if it were a namespace.

example with the change:
```cpp
TEST_SUITE("suite") {
TEST_CASE("case") {
  int k;
}
}  // TEST_SUITE("suite")
```

without this PR:

```cpp
TEST_SUITE("suite") {
  TEST_CASE("case") {
    int k;
  }
}
```